### PR TITLE
Change: Improves function for packaging toolbox

### DIFF
--- a/code/+matbox/+tasks/packageToolbox.m
+++ b/code/+matbox/+tasks/packageToolbox.m
@@ -63,6 +63,10 @@ function newVersion = packageToolbox(projectRootDirectory, releaseType, versionS
     if ~isfolder( fileparts(toolboxOptions.OutputFile) )
         mkdir( fileparts(toolboxOptions.OutputFile) );
     end
+
+    warnState = warning('off', 'MATLAB:toolbox_packaging:packaging:FilesDoNotExistWarning');
+    cleanupObj = onCleanup(@(ws) warning(warnState));
+    
     matlab.addons.toolbox.packageToolbox(toolboxOptions);
 
     if ~nargout

--- a/code/+matbox/+toolbox/+internal/resolvePathFolders.m
+++ b/code/+matbox/+toolbox/+internal/resolvePathFolders.m
@@ -1,0 +1,75 @@
+function [toolboxPathFolders, cleanupObj] = resolvePathFolders(projectRootDirectory, options)
+% resolvePathFolders Resolves folders to include in the MATLAB path for a toolbox project.
+%
+% Syntax:
+%   [toolboxPathFolders, cleanupObj] = matbox.toolbox.internal.resolvePathFolders(...
+%       projectRootDirectory, options) determines the folders within a
+%       specified project root directory to include in the MATLAB path for a 
+%       toolbox. It recursively identifies path folders within a specified 
+%       source folder or uses a list of custom path folders if provided.
+%
+% Inputs:
+%   projectRootDirectory (string) - The root directory of the project where
+%       the toolbox code is located.
+%
+%   options (struct) - Optional name-value pair arguments:
+%       - SourceFolderName (string): The name of the folder containing
+%         source code within `projectRootDirectory`. Default is "code".
+%       - PathFolders (string array): A custom list of path folders. If
+%         empty, folders within `SourceFolderName` are used.
+%
+% Outputs:
+%   toolboxPathFolders (string array) - An array of folder paths to be
+%       included in the MATLAB path for a toolbox.
+%
+%   cleanupObj (onCleanup) - An object that automatically deletes any
+%       temporary `Contents.m` files created in empty folders when it goes
+%       out of scope.
+%
+% Note: Due to a bug in matlab.addons.toolbox.ToolboxOptions it is not
+% possible to specify folders for the path which does not contain at least
+% one file. I.e if a folder that should be added to the path contains only
+% subfolders and no files, the ToolboxOptions class throws an error. To work
+% around this, if a folder does not contain any immediate files, a
+% temporary file is created. This file is deleted when the cleanupObj is
+% cleared
+
+    arguments
+        projectRootDirectory (1,1) string {mustBeFolder}
+        options.SourceFolderName (1,1) string = "code"
+        options.PathFolders (1,:) string = string.empty
+    end
+    
+    if isempty(options.PathFolders)
+        toolboxCodeFolder = fullfile(projectRootDirectory, options.SourceFolderName);        
+        toolboxPathFolders = string( strsplit(genpath(toolboxCodeFolder), pathsep));
+        toolboxPathFolders = toolboxPathFolders(1:end-1); % Last element is empty
+    else
+        toolboxPathFolders = repmat("", 1, numel(options.PathFolders));
+        for i = 1:numel(options.PathFolders)
+            if ~startsWith(options.PathFolders, projectRootDirectory)
+                toolboxPathFolders(i) = fullfile(projectRootDirectory, options.PathFolders(i));
+            else
+                toolboxPathFolders(i) = options.PathFolders(i);
+            end
+        end
+    end
+
+    tempFiles = string.empty;
+    for i = 1:numel(toolboxPathFolders)
+        L = dir(fullfile(toolboxPathFolders(i), '*.m'));
+        if isempty(L)
+            tempFiles(end+1) = fullfile(toolboxPathFolders(i), 'Contents.m'); %#ok<AGROW>
+            fid = fopen(tempFiles(end), 'wt');
+            fwrite(fid, '% Temporary placeholder');
+            fclose(fid);
+        end
+    end
+    cleanupObj = onCleanup(@(flist) deleteFiles(tempFiles) );
+end
+
+function deleteFiles(fileList)
+    for i = 1:numel(fileList)
+        delete(fileList(i))
+    end
+end

--- a/code/+matbox/+toolbox/readToolboxInfo.m
+++ b/code/+matbox/+toolbox/readToolboxInfo.m
@@ -18,10 +18,23 @@ function [toolboxOptions, identifier, toolboxInfo] = readToolboxInfo(projectRoot
               'Multiple instances of "MLToolboxInfo.json" were found in the project root directory. Please ensure there is only one file.');
     end
 
+    % Load options from MLToolboxInfo json file
     toolboxInfoFilePath = fullfile(fileListing.folder, fileListing.name);
     toolboxInfo = jsondecode(fileread(toolboxInfoFilePath));
     toolboxOptions = toolboxInfo.ToolboxOptions;
-    
+        
+    % Expand path names by prepending project root directory
+    pathOptions = ["ToolboxImageFile", "ToolboxGettingStartedGuide"];
+    for iPathOption = 1:numel(pathOptions)
+        iOptionName = pathOptions(iPathOption);
+        if isfield(toolboxOptions, iOptionName)
+            iOptionValue = toolboxOptions.(iOptionName);
+            if ~startsWith(iOptionValue, projectRootDir)
+                toolboxOptions.(iOptionName) = fullfile(projectRootDir, iOptionValue);
+            end
+        end
+    end
+
     if nargout >= 2
         % Get toolbox identifier and remove it from toolbox info
         identifier = toolboxOptions.Identifier;


### PR DESCRIPTION
- Work around a bug in matlab.addons.toolbox.ToolboxOptions that prevents adding folders with only subfolders (and no files) to the toolbox path
- Support adding "ToolboxImageFile" and "ToolboxGettingStartedGuide" to MLToolboxInfo