### PR TITLE
Change: Improve code analysis tools

### DIFF
--- a/code/+matbox/+codespell/+internal/addToIgnore.m
+++ b/code/+matbox/+codespell/+internal/addToIgnore.m
@@ -1,14 +1,45 @@
 function addToIgnore(word, ignoreFilePath)
     
-    if isfile(ignoreFilePath)
-        fileContent = fileread(ignoreFilePath);
-        fileContent = [fileContent, word, newline];
-    else
-        fileContent = '';
+    [~, ~, fileExt] = fileparts(ignoreFilePath);
+
+    if strcmp(fileExt, '.codespell_ignore')
+        if isfile(ignoreFilePath)
+            fileContent = fileread(ignoreFilePath);
+            fileContent = [fileContent, word, newline];
+        else
+            fileContent = '';
+        end
+        
+    elseif strcmp(fileExt, '.codespellrc')
+        if isfile(ignoreFilePath)
+            fileContent = fileread(ignoreFilePath);
+        else
+            error('MatBox:Codespell', 'Codespell config file does not exist')
+        end
+
+        fileLines = string( splitlines(fileContent) );
+        fileLines(fileLines=="") = [];
+
+        isIgnoreWordsLine = startsWith(fileLines, 'ignore-words-list');
+        if ~any(isIgnoreWordsLine)
+            ignoreWordsLineIdx = numel(fileLines)+1;
+            ignoreWords = string.empty;
+        else
+            ignoreWordsLineIdx = find(isIgnoreWordsLine);
+            ignoreWordsLineSplit = strsplit(fileLines(isIgnoreWordsLine), "=");
+            ignoreWords = strtrim( strsplit(ignoreWordsLineSplit(2), ',') );
+        end
+        ignoreWords(end+1) = word;
+        ignoreWords = unique(ignoreWords);
+
+        ignoreWordsStr = sprintf("ignore-words-list = %s", strjoin(ignoreWords, ', '));
+        fileLines(ignoreWordsLineIdx) = ignoreWordsStr;
+        fileContent = strjoin(fileLines, newline);
+        fileContent = fileContent +  newline;
     end
+
     fid = fopen(ignoreFilePath, 'wt');
     fwrite(fid, fileContent);
     fclose(fid);
-
-    fprintf('Added "%s" to ignore file\n', word)
+    fprintf('Added "%s" to codespell configuration file\n', word)
 end

--- a/code/+matbox/+tasks/codecheckToolbox.m
+++ b/code/+matbox/+tasks/codecheckToolbox.m
@@ -7,10 +7,15 @@ function issues = codecheckToolbox(projectRootDir, options)
         options.SeverityThreshold (1,1) string ...
             {mustBeMember(options.SeverityThreshold, ["info", "warning", "error"])} = "warning"
         options.SaveReport (1,1) logical = true
+        options.FilesToCheck (1,:) string = string.empty
     end
 
-    toolboxFileInfo = dir(fullfile(projectRootDir, "**", "*.m"));
-    filesToCheck = fullfile(string({toolboxFileInfo.folder}'),string({toolboxFileInfo.name}'));
+    if isempty(options.FilesToCheck)
+        toolboxFileInfo = dir(fullfile(projectRootDir, "**", "*.m"));
+        filesToCheck = fullfile(string({toolboxFileInfo.folder}'),string({toolboxFileInfo.name}'));
+    else
+        filesToCheck = options.FilesToCheck;
+    end
     
     if isempty(filesToCheck)
         error("MatBox:CodeIssues", "No files to check.")

--- a/code/+matbox/+tasks/codespellToolbox.m
+++ b/code/+matbox/+tasks/codespellToolbox.m
@@ -8,6 +8,7 @@ function codespellToolbox(codeFolder, options)
         codeFolder (1,1) string {mustBeFolder} = pwd
         options.DoAutomaticFix (1,1) logical = false
         options.IgnoreFilePath (1,1) string = ".codespell_ignore"
+        options.ConfigFilePath (1,1) string = ".codespellrc"
         options.Skip (1,:) string = string.empty
         options.CodeSpellExecutable (1,1) string = '/opt/homebrew/bin/codespell';
         options.RequireCodespellPassing (1,1) logical = false
@@ -28,6 +29,10 @@ function codespellToolbox(codeFolder, options)
         commandStr = sprintf("%s --write-changes", commandStr);
     end
 
+    if ~ismissing(options.ConfigFilePath) && isfile(options.ConfigFilePath)
+        options.IgnoreFilePath = string(missing);
+    end
+
     if ~ismissing(options.IgnoreFilePath)
         commandStr = sprintf("%s --ignore-words %s", commandStr, options.IgnoreFilePath);
         if ~isfile(options.IgnoreFilePath)
@@ -35,6 +40,8 @@ function codespellToolbox(codeFolder, options)
             fwrite(fid, '');
             fclose(fid);
         end
+    elseif ~ismissing(options.ConfigFilePath)
+        commandStr = sprintf("%s --config %s", commandStr, options.ConfigFilePath);
     end
 
     if ~isempty(options.Skip)
@@ -93,6 +100,8 @@ function codespellToolbox(codeFolder, options)
 
             if ~ismissing(options.IgnoreFilePath)
                 S(i).Ignore = createIgnoreLink(S(i).Word, options.IgnoreFilePath);
+            elseif ~ismissing(options.ConfigFilePath)
+                S(i).Ignore = createIgnoreLink(S(i).Word, options.ConfigFilePath);
             end
         end
         


### PR DESCRIPTION
- Add `FilesToCheck` option to `matbox.tasks.codecheckToolbox` providing a way to supply a custom list of files to run analysis on
- Add `ConfigFilePath` option to `matbox.tasks.codespellToolbox`, allowing to pass a code spell configuration file path (i.e `codespellrc`)