### PR TITLE
Add option for adding/not adding installed packages to path

### DIFF
--- a/code/+matbox/+setup/+internal/installFexPackage.m
+++ b/code/+matbox/+setup/+internal/installFexPackage.m
@@ -1,4 +1,4 @@
-function installFexPackage(toolboxIdentifier, installLocation, options)
+function packageTargetFolder = installFexPackage(toolboxIdentifier, installLocation, options)
 % installFexPackage - Install a FileExchange package
 %
 %   This function installs a package from FileExchange. If the package is
@@ -8,14 +8,14 @@ function installFexPackage(toolboxIdentifier, installLocation, options)
 
 %   Todo:
 %   [ ] Separate method for downloading
-%   [ ] Unclear if downloaded zip is added to path. Is this the
-%       responsibility of this function or upstream?
 
     arguments
         toolboxIdentifier
         installLocation
         options.Name (1,1) string = missing
         options.Version (1,1) string = missing
+        options.AddToPath (1,1) logical = true
+        options.AddToPathWithSubfolders (1,1) logical = true
     end
 
     % Check if toolbox is installed
@@ -68,17 +68,29 @@ function installFexPackage(toolboxIdentifier, installLocation, options)
         if endsWith(addonUrl, '/zip')
             [tempFilepath, C] = matbox.setup.internal.utility.tempsave(addonUrl, [toolboxIdentifier, '_temp.zip']);
 
-            installLocation = fullfile(installLocation, toolboxName);
-            if ~isfolder(installLocation); mkdir(installLocation); end
-            unzip(tempFilepath, installLocation);
+            packageTargetFolder = fullfile(installLocation, toolboxName);
+            if ~isfolder(packageTargetFolder); mkdir(packageTargetFolder); end
+            unzip(tempFilepath, packageTargetFolder);
+            if options.AddToPath
+                if options.AddToPathWithSubfolders
+                    addpath(genpath(packageTargetFolder))
+                else
+                    addpath(packageTargetFolder)
+                end
+            end
 
         elseif endsWith(addonUrl, '/mltbx')
             [tempFilepath, C] = matbox.setup.internal.utility.tempsave(addonUrl, [toolboxIdentifier, '_temp.mltbx']);
             matlab.addons.install(tempFilepath);
+            packageTargetFolder = 'n/a'; % todo
         end
 
         delete(C)
         fprintf('Done\n')
+
+        if ~nargout
+            clear packageTargetFolder
+        end
     end
 end
 

--- a/code/+matbox/+setup/+internal/installGithubRepository.m
+++ b/code/+matbox/+setup/+internal/installGithubRepository.m
@@ -5,6 +5,8 @@ function repoTargetFolder = installGithubRepository(repositoryUrl, branchName, o
         branchName (1,1) string = "main"
         options.Update (1,1) logical = false
         options.InstallationLocation (1,1) string = matbox.setup.internal.getDefaultAddonFolder()
+        options.AddToPath (1,1) logical = true
+        options.AddToPathWithSubfolders (1,1) logical = true
     end
 
     if ismissing(branchName); branchName = "main"; end
@@ -45,7 +47,13 @@ function repoTargetFolder = installGithubRepository(repositoryUrl, branchName, o
     if isfile( setupFile )
         run( setupFile )
     else
-        addpath(genpath(repoTargetFolder));
+        if options.AddToPath
+            if options.AddToPathWithSubfolders
+                addpath(genpath(repoTargetFolder))
+            else
+                addpath(repoTargetFolder)
+            end
+        end
     end
 
     if ~nargout

--- a/code/+matbox/installRequirements.m
+++ b/code/+matbox/installRequirements.m
@@ -24,12 +24,21 @@ function installRequirements(toolboxFolder, mode, options)
     
     for i = 1:numel(reqs)
         switch reqs(i).Type
+            
             case 'GitHub'
                 [repoUrl, branchName] = parseGitHubUrl(reqs(i).URI);
-                matbox.setup.internal.installGithubRepository( repoUrl, branchName )
+                matbox.setup.internal.installGithubRepository( ...
+                    repoUrl, ...
+                    branchName, ...
+                    "AddToPath", options.UpdateSearchPath)
+
             case 'FileExchange'
                 [packageUuid, version] = getFEXPackageSpecification( reqs(i).URI );
-                matbox.setup.internal.installFexPackage(packageUuid, installationLocation, 'Version', version);
+                matbox.setup.internal.installFexPackage(...
+                    packageUuid, ...
+                    installationLocation, ...
+                    'Version', version, ...
+                    "AddToPath", options.UpdateSearchPath);
 
             case 'Unknown'
                 continue


### PR DESCRIPTION
This fixes a bug where options.UpdateSearchPath actually did not do anything in `matbox.installRequirements`