### PR TITLE
Fix bug when installing FileExchange requirements

### DIFF
--- a/code/+matbox/+setup/+internal/installFexPackage.m
+++ b/code/+matbox/+setup/+internal/installFexPackage.m
@@ -108,14 +108,18 @@ end
 
 function toolboxName = retrieveToolboxName(toolboxIdentifier)
     fex = matlab.addons.repositories.FileExchangeRepository();
-
-    additionalInfoUrl = fex.getAddonDetailsURL(toolboxIdentifier);
-    addonHtmlInfo = webread(additionalInfoUrl);
-    pattern = '<span id="titleText">(.*?)</span>';
-    title = regexp(addonHtmlInfo, pattern, 'tokens', 'once');
-    if ~isempty(title)
-        toolboxName = title{1};
-    else
+    
+    try
+        additionalInfoUrl = fex.getAddonDetailsURL(toolboxIdentifier);
+        addonHtmlInfo = webread(additionalInfoUrl);
+        pattern = '<span id="titleText">(.*?)</span>';
+        title = regexp(addonHtmlInfo, pattern, 'tokens', 'once');
+        if ~isempty(title)
+            toolboxName = title{1};
+        else
+            toolboxName = string(missing);
+        end
+    catch
         toolboxName = string(missing);
     end
 end

--- a/code/+matbox/+setup/+internal/installFexPackage.m
+++ b/code/+matbox/+setup/+internal/installFexPackage.m
@@ -25,6 +25,9 @@ function packageTargetFolder = installFexPackage(toolboxIdentifier, installLocat
 
     if isInstalled
         matlab.addons.enableAddon(toolboxIdentifier, version)
+        if options.Verbose
+            fprintf('Requirement "%s" is already installed. Skipping...\n', options.Title)
+        end
 
     else % Download toolbox
         fex = matlab.addons.repositories.FileExchangeRepository();

--- a/code/+matbox/+setup/+internal/installFexPackage.m
+++ b/code/+matbox/+setup/+internal/installFexPackage.m
@@ -13,6 +13,7 @@ function packageTargetFolder = installFexPackage(toolboxIdentifier, installLocat
         toolboxIdentifier
         installLocation
         options.Name (1,1) string = missing
+        options.Title (1,1) string = missing
         options.Version (1,1) string = missing
         options.AddToPath (1,1) logical = true
         options.AddToPathWithSubfolders (1,1) logical = true
@@ -55,6 +56,9 @@ function packageTargetFolder = installFexPackage(toolboxIdentifier, installLocat
         if ismissing(toolboxName)
             if ismissing(options.Name)
                 toolboxName = retrieveToolboxName(toolboxIdentifier);
+                if ismissing(toolboxName)
+                    toolboxName = options.Title;
+                end
             else
                 toolboxName = options.Name;
             end

--- a/code/+matbox/+setup/+internal/installFexPackage.m
+++ b/code/+matbox/+setup/+internal/installFexPackage.m
@@ -91,7 +91,11 @@ function packageTargetFolder = installFexPackage(toolboxIdentifier, installLocat
 
         elseif endsWith(addonUrl, '/mltbx')
             [tempFilepath, C] = matbox.setup.internal.utility.tempsave(addonUrl, [toolboxIdentifier, '_temp.mltbx']);
-            matlab.addons.install(tempFilepath);
+            installedAddon = matlab.addons.install(tempFilepath);
+            if isempty(installedAddon)
+                fprintf(newline)
+                error('Failed to install "%s"...', toolboxName)
+            end
             packageTargetFolder = 'n/a'; % todo
         end
 

--- a/code/+matbox/installRequirements.m
+++ b/code/+matbox/installRequirements.m
@@ -37,11 +37,12 @@ function installRequirements(toolboxFolder, mode, options)
                     "Verbose", options.Verbose)
 
             case 'FileExchange'
-                [packageUuid, version] = getFEXPackageSpecification( reqs(i).URI );
+                [packageUuid, title, version] = getFEXPackageSpecification( reqs(i).URI );
                 matbox.setup.internal.installFexPackage(...
                     packageUuid, ...
                     installationLocation, ...
-                    'Version', version, ...
+                    "Title", title, ...
+                    "Version", version, ...
                     "AddToPath", options.UpdateSearchPath, ...
                     "Verbose", options.Verbose);
 
@@ -54,7 +55,7 @@ function installRequirements(toolboxFolder, mode, options)
     end
 end
 
-function [packageUuid, version] = getFEXPackageSpecification(uri)
+function [packageUuid, title, version] = getFEXPackageSpecification(uri)
 % getFEXPackageSpecification - Get UUID and version for package
 %
 %   NB: This function relies on an undocumented api, and might break in the
@@ -67,6 +68,7 @@ function [packageUuid, version] = getFEXPackageSpecification(uri)
     splitUri = strsplit(uri, '/');
 
     packageNumber = regexp(splitUri{2}, '\d*(?=-)', 'match', 'once');
+    title = extractAfter(splitUri{2}, [packageNumber '-']);
     try
         packageInfo = webread(FEX_API_URL + num2str(packageNumber));
         packageUuid = packageInfo.uuid;


### PR DESCRIPTION
- Fix bug causing failure when installing a FEX requirement where it is not possible to retrieve the toolbox name using the getAdditionalDetails endpoint. Use the toolbox title from the fex url in the requirements file if toolbox name can not be resolved
- Add print statement if a requirement exists already
- Throw error if a toolbox installation is aborted, i.e if a user cancels the license agreement dialog