### PR TITLE
Update packageToolbox.m

### DIFF
--- a/tools/tasks/packageToolbox.m
+++ b/tools/tasks/packageToolbox.m
@@ -1,12 +1,21 @@
-function [newVersion, mltbxPath] = packageToolbox(releaseType, versionString)
+function [newVersion, mltbxPath] = packageToolbox(releaseType, versionString, varargin)
     arguments
         releaseType {mustBeTextScalar,mustBeMember(releaseType,["build","major","minor","patch","specific"])} = "build"
         versionString {mustBeTextScalar} = "";
     end
-    installMatBox()
+    arguments (Repeating)
+        varargin
+    end
+
+    if ~(exist('+matbox/installRequirements', 'file') == 2)
+        installMatBox()
+    end
+
     projectRootDir = matboxtools.projectdir();
     addpath(genpath(projectRootDir))
+
     [newVersion, mltbxPath] = matbox.tasks.packageToolbox(...
         projectRootDir, releaseType, versionString, ...
+        varargin{:}, ...
         "SourceFolderName", "code");
 end


### PR DESCRIPTION
* The `packageToolbox` function now accepts additional optional arguments using `varargin`, allowing for greater customization when calling the function.
* Added a check to ensure that the `+matbox/installRequirements` file exists; if not, the `installMatBox()` function is called to install necessary dependencies before packaging.