### PR TITLE
docs: update third-party notices to climatedatastore's BSD-3 license

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,7 +8,7 @@ code and remain subject to the original license terms reproduced here.
 
 The following files are adapted from build utilities and workflows in
 [mathworks/climatedatastore](https://github.com/mathworks/climatedatastore),
-Copyright (c) 2021-2022, The MathWorks, Inc.:
+Copyright (c) The MathWorks, Inc.:
 
 | MatBox file | Adapted from |
 |---|---|
@@ -20,28 +20,32 @@ Copyright (c) 2021-2022, The MathWorks, Inc.:
 | `code/+matbox/+utility/writeBadgeJSONFile.m` | `buildUtilities/writeBadgeJSONFile.m` |
 | `.github/workflows/create_release.yml` | `.github/workflows/release.yml` |
 
-These portions are distributed under the following license. Note that, per
-condition 3, modifications and derivatives of this code are licensed solely
-for use in conjunction with MathWorks products and service offerings; MatBox
-is a MATLAB toolbox and is used exclusively with MATLAB.
+These portions are distributed under the BSD 3-Clause License reproduced
+below, as published by mathworks/climatedatastore. (The climatedatastore
+project relicensed from a custom license to BSD 3-Clause; see
+[mathworks/climatedatastore#35](https://github.com/mathworks/climatedatastore/issues/35).)
 
 ```text
-Copyright (c) 2021-2022, The MathWorks, Inc.
+Copyright (c) 2026, The MathWorks, Inc.
 All rights reserved.
+
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-3. In all cases, the software is, and all modifications and derivatives of
-   the software shall be, licensed to you solely for use in conjunction with
-   MathWorks products and service offerings.
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution
+    * Neither the name of the The MathWorks, Inc. nor the names
+      of its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
 LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS


### PR DESCRIPTION
## Summary

Following [mathworks/climatedatastore#35](https://github.com/mathworks/climatedatastore/issues/35), climatedatastore relicensed from its custom license (BSD-2-style plus a MathWorks-products-only clause) to standard **BSD 3-Clause** — verified against their current `license.txt`, which GitHub now detects as BSD-3-Clause.

This updates `THIRD_PARTY_NOTICES.md` accordingly:

- Reproduces the new BSD-3 license text verbatim (with a pointer to the relicensing discussion)
- Removes the paragraph about the old products-only condition, which no longer exists
- File mapping table, per-file attribution headers, the LICENSE scoping note, and `.mltbx` packaging of the notices are unchanged — they already satisfy BSD-3's source and binary notice conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)