### PR TITLE
fix: forward the bump input to the release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,6 +26,7 @@ jobs:
     uses: ehennestad/matbox-actions/.github/workflows/prepare-release-workflow.yml@v1
     with:
       version: ${{ inputs.version }}
+      bump: ${{ inputs.bump }}
       ref_name: ${{ github.ref_name }}
       source_directory: code
       tests_directory: tools/tests


### PR DESCRIPTION
## Summary

Dispatching **Prepare toolbox release** with a bump type (and no explicit version) failed:

```
Tag name ('main') is not in the expected v*.*.* format.
```

The workflow declared the `bump` dispatch input (added in #64) but never forwarded it — the `with:` block only passed `version` and `ref_name`. A bump-only dispatch therefore sent an empty `version` to `prepare-release-workflow`, whose version validation fell back to interpreting `ref_name` (`main`) as a release tag.

One line: forward `bump: ${{ inputs.bump }}`, matching the matbox-actions workflow template.

## Dependency

Merging this requires **matbox-actions v1.6** (in flight): `@v1` currently resolves to v1.5, whose `prepare-release-workflow.yml` does not declare a `bump` input, and passing an undeclared input to a reusable workflow is a hard error. Once v1.6 is published and `v1` moves, this works as-is. Until then, the explicit `version` override input still works for releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)